### PR TITLE
fix: android deprecations

### DIFF
--- a/android/src/main/java/com/ioreactnativecieid/IoReactNativeCieidModule.kt
+++ b/android/src/main/java/com/ioreactnativecieid/IoReactNativeCieidModule.kt
@@ -51,10 +51,10 @@ class IoReactNativeCieidModule(reactContext: ReactApplicationContext) :
   // Extension function to handle API compatibility for getting signatures
   private fun PackageInfo.getSignaturesCompat(): Array<Signature> {
     return if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.P) {
-      signingInfo.apkContentsSigners
+      signingInfo?.apkContentsSigners ?: emptyArray()
     } else {
       @Suppress("DEPRECATION")
-      signatures
+      signatures ?: emptyArray()
     }
   }
 
@@ -85,7 +85,7 @@ class IoReactNativeCieidModule(reactContext: ReactApplicationContext) :
     url: String,
     resultCallback: Callback
   ) {
-    currentActivity?.let { activity ->
+    getReactApplicationContext().getCurrentActivity()?.let { activity ->
       val intent = Intent().apply {
         setClassName(packageName, className)
         data = Uri.parse(url)
@@ -118,7 +118,7 @@ class IoReactNativeCieidModule(reactContext: ReactApplicationContext) :
   }
 
   override fun onActivityResult(
-    activity: Activity?,
+    activity: Activity,
     requestCode: Int,
     resultCode: Int,
     data: Intent?
@@ -155,7 +155,7 @@ class IoReactNativeCieidModule(reactContext: ReactApplicationContext) :
     onActivityResultCallback = null
   }
 
-  override fun onNewIntent(intent: Intent?) {
+  override fun onNewIntent(intent: Intent) {
     // We do not expect add any data handling here,
     // but we add a log in case we need to debug some edge cases.
     Log.d(name, "onNewIntent has been called")


### PR DESCRIPTION
## Short description

On newer versions of React Native (Expo SDK 54), Gradle builds fail due to deprecated APIs.

## List of changes proposed in this pull request

The Android source code has been updated to replace deprecated method signatures and resolve type safety issues.
I’m not a Kotlin developer, but these changes appear to resolve the build errors.

## How to test
I don’t personally own a CIE, so I asked two coworkers (running Android 16 and Android 12) to test an app I maintain using this modified version of the library.